### PR TITLE
Make flutter_blue usable for Android and iOS

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -176,7 +176,13 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
                 result.success(null);
                 break;
             }
-
+            
+            case "setUniqueId":
+            {
+                result.success(null);
+                break;
+            }
+            
             case "state":
             {
                 Protos.BluetoothState.Builder p = Protos.BluetoothState.newBuilder();

--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -335,6 +335,7 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
                     mDevices.put(deviceId, new BluetoothDeviceCache(gattServer));
                     result.success(null);
                 });
+                break;
             }
 
             case "disconnect":
@@ -773,7 +774,7 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
         }
     };
 
-    private void startScan(MethodCall call, Result result) {
+    private void startScanImpl(MethodCall call, Result result) {
         byte[] data = call.arguments();
         Protos.ScanSettings settings;
         try {
@@ -789,6 +790,17 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
         } catch (Exception e) {
             result.error("startScan", e.getMessage(), e);
         }
+    }
+
+    private void startScan(MethodCall call, Result result) {
+        ensurePermissionBeforeAction(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? Manifest.permission.BLUETOOTH_CONNECT : null, (granted, permission) -> {
+            if (!granted) {
+                result.error(
+                        "no_permissions", String.format("flutter_blue plugin requires %s for obtaining connected devices", permission), null);
+                return;
+            }
+            startScanImpl(call, result);
+        });
     }
 
     private void stopScan() {

--- a/ios/Classes/FlutterBluePlugin.h
+++ b/ios/Classes/FlutterBluePlugin.h
@@ -12,6 +12,7 @@
 #define NAMESPACE @"plugins.pauldemarco.com/flutter_blue"
 
 @interface FlutterBluePlugin : NSObject<FlutterPlugin, CBCentralManagerDelegate, CBPeripheralDelegate>
++ (CBCentralManager*) prepCentralManager;
 @end
 
 @interface FlutterBlueStreamHandler : NSObject<FlutterStreamHandler>

--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -142,6 +142,10 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
       if( [peripheral state] == CBPeripheralStateDisconnected || [peripheral state] == CBPeripheralStateDisconnecting) {
         [self.centralManager connectPeripheral:peripheral options:nil];
       }
+
+      // Send connection state
+      [_channel invokeMethod:@"DeviceState" arguments:[self toFlutterData:[self toDeviceStateProto:peripheral state:peripheral.state]]];
+
       result(nil);
     } @catch(FlutterError *e) {
       result(e);

--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -171,6 +171,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     NSString *remoteId = [call arguments];
     @try {
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"discoverServices ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Clear helper arrays
       [_servicesThatNeedDiscovered removeAllObjects];
       [_characteristicsThatNeedDiscovered removeAllObjects ];
@@ -194,6 +201,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     @try {
       // Find peripheral
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"readCharacteristic ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Find characteristic
       CBCharacteristic *characteristic = [self locateCharacteristic:[request characteristicUuid] peripheral:peripheral serviceId:[request serviceUuid] secondaryServiceId:[request secondaryServiceUuid]];
       // Trigger a read
@@ -209,6 +223,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     @try {
       // Find peripheral
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"readDescriptor ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Find characteristic
       CBCharacteristic *characteristic = [self locateCharacteristic:[request characteristicUuid] peripheral:peripheral serviceId:[request serviceUuid] secondaryServiceId:[request secondaryServiceUuid]];
       // Find descriptor
@@ -225,6 +246,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     @try {
       // Find peripheral
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"writeCharacteristic ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Find characteristic
       CBCharacteristic *characteristic = [self locateCharacteristic:[request characteristicUuid] peripheral:peripheral serviceId:[request serviceUuid] secondaryServiceId:[request secondaryServiceUuid]];
       // Get correct write type
@@ -242,6 +270,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     @try {
       // Find peripheral
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"writeDescriptor ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Find characteristic
       CBCharacteristic *characteristic = [self locateCharacteristic:[request characteristicUuid] peripheral:peripheral serviceId:[request serviceUuid] secondaryServiceId:[request secondaryServiceUuid]];
       // Find descriptor
@@ -259,6 +294,13 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     @try {
       // Find peripheral
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
+
+      if([peripheral state] != CBPeripheralStateConnected) {
+        NSLog(@"setNotification ignoring non-connected peripheral");
+        result(nil);
+        return;
+      }
+
       // Find characteristic
       CBCharacteristic *characteristic = [self locateCharacteristic:[request characteristicUuid] peripheral:peripheral serviceId:[request serviceUuid] secondaryServiceId:[request secondaryServiceUuid]];
       // Set notification value

--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 @property(nonatomic) NSMutableArray *servicesThatNeedDiscovered;
 @property(nonatomic) NSMutableArray *characteristicsThatNeedDiscovered;
 @property(nonatomic) LogLevel logLevel;
+@property(nonatomic) NSString *uniqueId;
 @end
 
 @implementation FlutterBluePlugin
@@ -61,6 +62,14 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
   [registrar addMethodCallDelegate:instance channel:channel];
 }
 
+- (CBCentralManager*)centralManager{
+  if (!_centralManager){
+    _centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil
+            options:_uniqueId ? @{CBCentralManagerOptionRestoreIdentifierKey: _uniqueId} : @{}];
+  }
+  return _centralManager;
+}
+
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
   if ([@"setLogLevel" isEqualToString:call.method]) {
     NSNumber *logLevelIndex = [call arguments];
@@ -68,11 +77,16 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     result(nil);
     return;
   }
-  if (self.centralManager == nil) {
-    self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
-  }
-  if ([@"state" isEqualToString:call.method]) {
-    FlutterStandardTypedData *data = [self toFlutterData:[self toBluetoothStateProto:self->_centralManager.state]];
+
+  if([@"setUniqueId" isEqualToString:call.method]) {
+    _uniqueId = [call arguments];
+    if (!_centralManager){
+      result(@(YES));
+    } else {
+      result(@(NO));
+    }
+  } else if ([@"state" isEqualToString:call.method]) {
+    FlutterStandardTypedData *data = [self toFlutterData:[self toBluetoothStateProto:self.centralManager.state]];
     result(data);
   } else if([@"isAvailable" isEqualToString:call.method]) {
     if(self.centralManager.state != CBManagerStateUnsupported && self.centralManager.state != CBManagerStateUnknown) {
@@ -102,14 +116,14 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     if (request.allowDuplicates) {
         [scanOpts setObject:[NSNumber numberWithBool:YES] forKey:CBCentralManagerScanOptionAllowDuplicatesKey];
     }
-    [self->_centralManager scanForPeripheralsWithServices:uuids options:scanOpts];
+    [self.centralManager scanForPeripheralsWithServices:uuids options:scanOpts];
     result(nil);
   } else if([@"stopScan" isEqualToString:call.method]) {
-    [self->_centralManager stopScan];
+      [self.centralManager stopScan];
     result(nil);
   } else if([@"getConnectedDevices" isEqualToString:call.method]) {
     // Cannot pass blank UUID list for security reasons. Assume all devices have the Generic Access service 0x1800
-    NSArray *periphs = [self->_centralManager retrieveConnectedPeripheralsWithServices:@[[CBUUID UUIDWithString:@"1800"]]];
+    NSArray *periphs = [self.centralManager retrieveConnectedPeripheralsWithServices:@[[CBUUID UUIDWithString:@"1800"]]];
     NSLog(@"getConnectedDevices periphs size: %lu", [periphs count]);
     result([self toFlutterData:[self toConnectedDeviceResponseProto:periphs]]);
   } else if([@"connect" isEqualToString:call.method]) {
@@ -126,9 +140,8 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
       // TODO: Implement Connect options (#36)
       if( [peripheral state] == CBPeripheralStateDisconnected || [peripheral state] == CBPeripheralStateDisconnecting) {
-        [_centralManager connectPeripheral:peripheral options:nil];
+        [self.centralManager connectPeripheral:peripheral options:nil];
       }
-
       result(nil);
     } @catch(FlutterError *e) {
       result(e);
@@ -137,7 +150,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
     NSString *remoteId = [call arguments];
     @try {
       CBPeripheral *peripheral = [self findPeripheral:remoteId];
-      [_centralManager cancelPeripheralConnection:peripheral];
+      [self.centralManager cancelPeripheralConnection:peripheral];
       result(nil);
     } @catch(FlutterError *e) {
       result(e);
@@ -267,7 +280,7 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 }
 
 - (CBPeripheral*)findPeripheral:(NSString*)remoteId {
-  NSArray<CBPeripheral*> *peripherals = [_centralManager retrievePeripheralsWithIdentifiers:@[[[NSUUID alloc] initWithUUIDString:remoteId]]];
+  NSArray<CBPeripheral*> *peripherals = [self.centralManager retrievePeripheralsWithIdentifiers:@[[[NSUUID alloc] initWithUUIDString:remoteId]]];
   CBPeripheral *peripheral;
   for(CBPeripheral *p in peripherals) {
     if([[p.identifier UUIDString] isEqualToString:remoteId]) {
@@ -370,10 +383,15 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 //
 - (void)centralManagerDidUpdateState:(nonnull CBCentralManager *)central {
   if(_stateStreamHandler.sink != nil) {
-    FlutterStandardTypedData *data = [self toFlutterData:[self toBluetoothStateProto:self->_centralManager.state]];
+    FlutterStandardTypedData *data = [self toFlutterData:[self toBluetoothStateProto:self.centralManager.state]];
     self.stateStreamHandler.sink(data);
   }
 }
+
+- (void)centralManager:(CBCentralManager *)central willRestoreState:(NSDictionary<NSString *, id> *)dict {
+  NSLog(@"willRestoreState");
+}
+
 
 - (void)centralManager:(CBCentralManager *)central didDiscoverPeripheral:(CBPeripheral *)peripheral advertisementData:(NSDictionary<NSString *,id> *)advertisementData RSSI:(NSNumber *)RSSI {
   [self.scannedPeripherals setObject:peripheral

--- a/ios/Classes/FlutterBluePlugin.m
+++ b/ios/Classes/FlutterBluePlugin.m
@@ -123,8 +123,12 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
                                    message:@"Peripheral not found"
                                    details:nil];
       }
+
       // TODO: Implement Connect options (#36)
-      [_centralManager connectPeripheral:peripheral options:nil];
+      if( [peripheral state] == CBPeripheralStateDisconnected || [peripheral state] == CBPeripheralStateDisconnecting) {
+        [_centralManager connectPeripheral:peripheral options:nil];
+      }
+
       result(nil);
     } @catch(FlutterError *e) {
       result(e);
@@ -393,15 +397,43 @@ typedef NS_ENUM(NSUInteger, LogLevel) {
 
 - (void)centralManager:(CBCentralManager *)central didDisconnectPeripheral:(CBPeripheral *)peripheral error:(NSError *)error {
   NSLog(@"didDisconnectPeripheral");
-  // Unregister self as delegate for peripheral, not working #42
-  peripheral.delegate = nil;
+
+  // if user disconnect manually, error code should be 0
+  if( [error code] != 0 ){
+    // unexpected disconnection -> try reconnect
+    @try {
+      NSLog(@"didDisconnectPeripheral:trying reconnect");
+      // TODO: Implement Connect options (#36)
+      [central connectPeripheral:peripheral options:nil];
+    } @catch(FlutterError *e) {
+      NSLog(@"didDisconnectPeripheral:failed reconnect");
+    }
+  }else{
+    NSLog(@"didDisconnectPeripheral:user disconnected");
+    // Unregister self as delegate for peripheral, not working https://github.com/pauldemarco/flutter_blue/issues/42
+    peripheral.delegate = nil;
+  }
 
   // Send connection state
   [_channel invokeMethod:@"DeviceState" arguments:[self toFlutterData:[self toDeviceStateProto:peripheral state:peripheral.state]]];
 }
 
 - (void)centralManager:(CBCentralManager *)central didFailToConnectPeripheral:(CBPeripheral *)peripheral error:(NSError *)error {
-  // TODO:?
+  // TODO:? Just going to try to issue a reconnect
+  // https://developer.apple.com/forums/thread/105652
+  NSLog(@"didFailToConnectPeripheral");
+
+  // unexpected connection failure -> try connect again
+  @try {
+    NSLog(@"didFailToConnectPeripheral:trying connect");
+    // TODO: Implement Connect options (#36)
+    [central connectPeripheral:peripheral options:nil];
+  } @catch(FlutterError *e) {
+    NSLog(@"didFailToConnectPeripheral:failed connect");
+  }
+
+  // Send connection state
+  [_channel invokeMethod:@"DeviceState" arguments:[self toFlutterData:[self toDeviceStateProto:peripheral state:peripheral.state]]];
 }
 
 //

--- a/lib/flutter_blue.dart
+++ b/lib/flutter_blue.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:convert/convert.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';

--- a/lib/src/bluetooth_characteristic.dart
+++ b/lib/src/bluetooth_characteristic.dart
@@ -99,12 +99,28 @@ class BluetoothCharacteristic {
     });
   }
 
+  // Attempt to read a value, gracefully handling
+  // * timeouts
+  // * inconsistent peripheral service discovery
+  Future<List<int>?> tryRead(Duration timeout) async {
+    try {
+      return read()
+          .then((d) => Future<List<int>?>.value(d))
+          .timeout(timeout, onTimeout: () => null);
+    } on PlatformException catch (e) {
+      if (e.code == "locateCharacteristic") {
+        debugPrint('Silencing $e');
+        return Future.value(null);
+      }
+    }
+  }
+
   /// Writes the value of a characteristic.
   /// [CharacteristicWriteType.withoutResponse]: the write is not
   /// guaranteed and will return immediately with success.
   /// [CharacteristicWriteType.withResponse]: the method will return after the
   /// write operation has either passed or failed.
-  Future<Null> write(List<int> value, {bool withoutResponse = false}) async {
+  Future<bool> write(List<int> value, {bool withoutResponse = false}) async {
     final type = withoutResponse
         ? CharacteristicWriteType.withoutResponse
         : CharacteristicWriteType.withResponse;
@@ -137,8 +153,25 @@ class BluetoothCharacteristic {
         .then((w) => w.success)
         .then((success) => (!success)
             ? throw new Exception('Failed to write the characteristic')
-            : null)
-        .then((_) => null);
+            : true)
+        .then((_) => true);
+  }
+
+  // Attempt to write a value, gracefully handling
+  // * timeouts
+  // * inconsistent peripheral service discovery
+  Future<bool?> tryWrite(List<int> value, Duration timeout,
+      {bool withoutResponse = false}) async {
+    try {
+      return write(value, withoutResponse: withoutResponse)
+          .then((b) => Future<bool?>.value(b))
+          .timeout(timeout, onTimeout: () => null);
+    } on PlatformException catch (e) {
+      if (e.code == "locateCharacteristic") {
+        debugPrint('Silencing $e');
+        return Future.value(null);
+      }
+    }
   }
 
   /// Sets notifications or indications for the value of a specified characteristic

--- a/lib/src/flutter_blue.dart
+++ b/lib/src/flutter_blue.dart
@@ -104,12 +104,13 @@ class FlutterBlue {
         .then((p) => p.map((d) => BluetoothDevice.fromProto(d)).toList());
   }
 
-  /// Starts a scan for Bluetooth Low Energy devices and returns a stream
-  /// of the [ScanResult] results as they are received.
-  ///
-  /// timeout calls stopStream after a specified [Duration].
-  /// You can also get a list of ongoing results in the [scanResults] stream.
-  /// If scanning is already in progress, this will throw an [Exception].
+  /// Sets a unique id (required on iOS for restoring app on background-scan)
+  /// should be called before any other methods.
+  Future setUniqueId(String uniqueid) =>
+      _channel.invokeMethod('setUniqueId', uniqueid.toString());
+
+  /// Starts a scan for Bluetooth Low Energy devices
+  /// Timeout closes the stream after a specified [Duration]
   Stream<ScanResult> scan({
     ScanMode scanMode = ScanMode.lowLatency,
     List<Guid> withServices = const [],


### PR DESCRIPTION
Without auto reconnect and without background restoration, flutter_blue is really only useful in concept; it requires an active foreground iOS application for the duration of the interaction with a CoreBluetooth peripheral.

I have several applications that require various basic functionalities such as auto reconnect to work on iOS and Android. master is tracking changes for making various use cases work for both iOS and Android. I am tackling iOS changes first because I am much more familiar with CoreBluetooth. 

Target use cases for Android and iOS:
* 24/7 connected streaming environmental data
* Real-time graphing (from B/s to 40KB/s)
* Async file or network I/O from characteristic notification
    * L2CAP stream interface preferred but unlikely
* Graceful handling of flaky peripheral signal quality
* Orchestrating multiple peripherals' configuration via characteristic writes or writes w/o responses


