### PR TITLE
Android: Add missing break in switch, which causes exceptions

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -329,6 +329,7 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
                     mDevices.put(deviceId, new BluetoothDeviceCache(gattServer));
                     result.success(null);
                 });
+                break;
             }
 
             case "disconnect":


### PR DESCRIPTION
Should be pretty uncontroversial--it falls through and then throws an exception when the argument cast fails. 