### PR TITLE
On Android OS 12 scanning for devices would crash when trying to get the name of the Bluetooth device because it needed BLUETOOTH_CONNECT permissions to do so.

### DIFF
--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -329,6 +329,7 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
                     mDevices.put(deviceId, new BluetoothDeviceCache(gattServer));
                     result.success(null);
                 });
+                break;
             }
 
             case "disconnect":

--- a/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
+++ b/android/src/main/java/com/pauldemarco/flutter_blue/FlutterBluePlugin.java
@@ -767,7 +767,7 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
         }
     };
 
-    private void startScan(MethodCall call, Result result) {
+    private void startScanImpl(MethodCall call, Result result) {
         byte[] data = call.arguments();
         Protos.ScanSettings settings;
         try {
@@ -783,6 +783,17 @@ public class FlutterBluePlugin implements FlutterPlugin, MethodCallHandler, Requ
         } catch (Exception e) {
             result.error("startScan", e.getMessage(), e);
         }
+    }
+
+    private void startScan(MethodCall call, Result result) {
+        ensurePermissionBeforeAction(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? Manifest.permission.BLUETOOTH_CONNECT : null, (granted, permission) -> {
+            if (!granted) {
+                result.error(
+                        "no_permissions", String.format("flutter_blue plugin requires %s for obtaining connected devices", permission), null);
+                return;
+            }
+            startScanImpl(call, result);
+        });
     }
 
     private void stopScan() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_blue
 description:
   Flutter plugin for connecting and communicating with Bluetooth Low Energy devices,
   on Android and iOS
-version: 0.13.0
+version: 0.13.1
 homepage: https://github.com/pauldemarco/flutter_blue
 
 environment:


### PR DESCRIPTION
This is the first time I've made a pull request. I hope that I'm doing this right.

See https://github.com/boskokg/flutter_blue/issues/19 for the stack crawl.